### PR TITLE
davinci uses custom recovery

### DIFF
--- a/_data/devices/davinci.yml
+++ b/_data/devices/davinci.yml
@@ -61,6 +61,7 @@ screen_tech: AMOLED
 sdcard: null
 soc: Qualcomm SM7150-AA Snapdragon 730
 storage: 64/128/256 GB
+uses_custom_recovery: true
 vendor: Xiaomi
 versions:
 - eleven


### PR DESCRIPTION
Change-Id: Ie54d89c23fd28958812859447e632709c7332cd2