### PR TITLE
evert: Use twrp

### DIFF
--- a/_data/devices/evert.yml
+++ b/_data/devices/evert.yml
@@ -64,6 +64,7 @@ screen_tech: IPS LCD
 sdcard: Up to 256 GB
 soc: Qualcomm SDM630 Snapdragon 630
 storage: 64/128 GB
+uses_twrp: true
 vendor: Motorola
 versions:
 - eleven


### PR DESCRIPTION
* Installing pe recovery before flashing copy-partitions caused soft brick on some devices