### PR TITLE
evert: Use custom recovery

### DIFF
--- a/_data/devices/evert.yml
+++ b/_data/devices/evert.yml
@@ -20,6 +20,7 @@ codename: evert
 cpu: Cortex-A53
 cpu_cores: '8'
 cpu_freq: 2.2 GHz
+custom_recovery_link: https://t.me/pe_evert/5208
 depth: 8.0 mm (0.31 in)
 download_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>Power</kbd>.
 gpu: Adreno 508
@@ -64,6 +65,7 @@ screen_tech: IPS LCD
 sdcard: Up to 256 GB
 soc: Qualcomm SDM630 Snapdragon 630
 storage: 64/128 GB
+uses_custom_recovery: true
 vendor: Motorola
 versions:
 - eleven


### PR DESCRIPTION
* Installing pe recovery before flashing copy-partitions cause soft brick on some devices