### PR TITLE
Revert "davinci uses custom recovery"

### DIFF
--- a/_data/devices/davinci.yml
+++ b/_data/devices/davinci.yml
@@ -61,7 +61,6 @@ screen_tech: AMOLED
 sdcard: null
 soc: Qualcomm SM7150-AA Snapdragon 730
 storage: 64/128/256 GB
-uses_custom_recovery: true
 vendor: Xiaomi
 versions:
 - eleven


### PR DESCRIPTION
Users are apparently confused with TWRP's options, so lets ship AOSP Recovery, and suggest them to use this