### PR TITLE
xiaomi-family: Drop the recommendation to use weekly firmware

### DIFF
--- a/_includes/templates/recovery_install_fastboot_xiaomi.md
+++ b/_includes/templates/recovery_install_fastboot_xiaomi.md
@@ -4,7 +4,7 @@
 
 {% include alerts/note.html content="The steps below only need to be run once per device." %}
 {% include alerts/warning.html content="Unlocking the bootloader will erase all data on your device! Before proceeding, ensure the data you would like to retain is backed up to your PC and/or your Google account, or equivalent. Please note that OEM backup solutions like Samsung and Motorola backup may not be accessible from PixelExperience once installed." %}
-{% include alerts/tip.html content="It is highly recommended to have the latest official MIUI weekly package installed on the device, before proceeding with unlock." %}
+
 {% include alerts/note.html content="The following instructions **require** a machine running Windows 7 or newer." %}
 
 1. Create a Mi account on [Xiaomi's website](https://global.account.xiaomi.com/pass/register).
@@ -27,6 +27,3 @@
 {% endif %}
 
 {% include templates/recovery_install_fastboot_generic.md %}
-{% if device.no_oem_unlock_switch %}
-{% include alerts/tip.html content="It is highly recommended to have the latest official MIUI weekly package installed on the device, before installing a custom recovery." %}
-{% endif %}

--- a/_includes/templates/recovery_install_fastboot_xiaomi_virtual_ab.md
+++ b/_includes/templates/recovery_install_fastboot_xiaomi_virtual_ab.md
@@ -4,7 +4,7 @@
 
 {% include alerts/note.html content="The steps below only need to be run once per device." %}
 {% include alerts/warning.html content="Unlocking the bootloader will erase all data on your device! Before proceeding, ensure the data you would like to retain is backed up to your PC and/or your Google account, or equivalent. Please note that OEM backup solutions like Samsung and Motorola backup may not be accessible from PixelExperience once installed." %}
-{% include alerts/tip.html content="It is highly recommended to have the latest official MIUI weekly package installed on the device, before proceeding with unlock." %}
+
 {% include alerts/note.html content="The following instructions **require** a machine running Windows 7 or newer." %}
 
 1. Create a Mi account on [Xiaomi's website](https://global.account.xiaomi.com/pass/register).
@@ -22,6 +22,3 @@
 {% endunless %}
 
 {% include templates/recovery_install_fastboot_ab.md %}
-{% if device.no_oem_unlock_switch %}
-{% include alerts/tip.html content="It is highly recommended to have the latest official MIUI weekly package installed on the device, before installing a custom recovery." %}
-{% endif %}


### PR DESCRIPTION
Weekly is issued only for china now, and using it on a non-chinese device breaks L1 on pre-kona devices, advise devices to use before_install_needs_specific_android_fw to indicate which firmware they need to.
