### PR TITLE
avicii: Disable custom avb key

### DIFF
--- a/_data/devices/avicii.yml
+++ b/_data/devices/avicii.yml
@@ -1,4 +1,3 @@
-after_install_custom: avb_key
 architecture:
   cpu: arm64
   userspace: arm


### PR DESCRIPTION
* Doesn't bring back L1 anyways and broken on A12 so will fix later