### PR TITLE
alioth: Make it clear that Android 11 firmware is required

### DIFF
--- a/_data/devices/alioth.yml
+++ b/_data/devices/alioth.yml
@@ -3,6 +3,8 @@ battery:
   capacity: 4520
   removable: false
   tech: Li-Po
+before_install: needs_specific_android_fw
+before_install_args: {version: 11}
 bluetooth:
   profiles:
   - A2DP


### PR DESCRIPTION
Lines stolen from https://github.com/LineageOS/lineage_wiki/blob/master/_data/devices/alioth.yml#L3-L4