### PR TITLE
wiki: test: schema-06: Add Adreno 642 entry

### DIFF
--- a/test/schema-06.yml
+++ b/test/schema-06.yml
@@ -448,6 +448,7 @@ properties:
     - Adreno 620
     - Adreno 630
     - Adreno 640
+    - Adreno 642
     - Adreno 650
     - Adreno 660
     - Adreno 675


### PR DESCRIPTION
Signed-off-by: ArixElo <patroxgamer@gmail.com>
It's required for Mi 11 Lite 5G, which it's SoC has that GPU.