### PR TITLE
wiki: renoir: Add flashing vendor_boot image step

### DIFF
--- a/_data/devices/renoir.yml
+++ b/_data/devices/renoir.yml
@@ -4,6 +4,7 @@ battery:
   removable: false
   tech: Li-Po
 before_install: renoir
+before_recovery_install: vendor_boot
 bluetooth:
   profiles:
   - A2DP + aptX HD
@@ -68,6 +69,7 @@ screen:
 soc: Qualcomm SM7350-AB Snapdragon 780
 storage: 64/128/256 GB
 vendor: Xiaomi
+vendor_boot_download_link: https://github.com/PixelExperience-Devices/wiki_renoir_blobs/raw/main/twelve/vendor_boot.img
 versions:
 - twelve
 - twelve_plus

--- a/test/schema-06.yml
+++ b/test/schema-06.yml
@@ -448,6 +448,7 @@ properties:
     - Adreno 620
     - Adreno 630
     - Adreno 640
+    - Adreno 642
     - Adreno 650
     - Adreno 660
     - Adreno 675


### PR DESCRIPTION
It's required since renoir is a Virtual A/B device.
take two
Signed-off-by: ArixElo <patroxgamer@gmail.com>