### PR TITLE
Revert "alioth: Make it clear that Android 11 firmware is required (#…

### DIFF
--- a/_data/devices/alioth.yml
+++ b/_data/devices/alioth.yml
@@ -3,9 +3,6 @@ battery:
   capacity: 4520
   removable: false
   tech: Li-Po
-before_install: needs_specific_android_fw
-before_install_args:
-  version: 11
 bluetooth:
   profiles:
   - A2DP


### PR DESCRIPTION
…173)"

This reverts commit 6c3199b87a681a7a8298ccee9585ac912b341d30.

Newer builds automatically flash the required firmware, so this warning is no longer needed.