### PR TITLE
monet/vangogh: remove before_install (firmware) step

### DIFF
--- a/_data/devices/monet.yml
+++ b/_data/devices/monet.yml
@@ -3,7 +3,6 @@ battery:
   capacity: 4160
   removable: false
   tech: Li-Po
-before_install: monet
 bluetooth:
   profiles:
   - A2DP + aptX HD

--- a/_data/devices/vangogh.yml
+++ b/_data/devices/vangogh.yml
@@ -3,7 +3,6 @@ battery:
   capacity: 4160
   removable: false
   tech: Li-Po
-before_install: vangogh
 bluetooth:
   profiles:
   - A2DP + aptX HD

--- a/_includes/templates/device_specific/before_install_monet.md
+++ b/_includes/templates/device_specific/before_install_monet.md
@@ -1,1 +1,0 @@
-{% include alerts/warning.html content="Before following these instructions, please flash V12.5.5.0.RJIEUXM Stable firmware. You can download it from [here](https://xiaomifirmwareupdater.com/firmware/monet/stable/V12.5.5.0.RJIEUXM/)"%}

--- a/_includes/templates/device_specific/before_install_vangogh.md
+++ b/_includes/templates/device_specific/before_install_vangogh.md
@@ -1,1 +1,0 @@
-{% include alerts/warning.html content="Before following these instructions, please flash V12.1.7.0.RJVCNXM Stable firmware. You can download it from [here](https://xiaomifirmwareupdater.com/firmware/vangogh/stable/V12.1.7.0.RJVCNXM/)"%}


### PR DESCRIPTION
Firmware is now included in the ROM while flashing so not needed anymore.
