### PR TITLE
wiki: alioth: install vendor_boot before recovery

### DIFF
--- a/_data/devices/alioth.yml
+++ b/_data/devices/alioth.yml
@@ -3,6 +3,7 @@ battery:
   capacity: 4520
   removable: false
   tech: Li-Po
+before_recovery_install: vendor_boot
 bluetooth:
   profiles:
   - A2DP
@@ -69,6 +70,7 @@ screen:
 soc: Qualcomm SM8250-AC Snapdragon 870
 storage: 128/256 GB
 vendor: Xiaomi
+vendor_boot_download_link: https://gitlab.pixelexperience.org/android/vendor-blobs/wiki_blobs_alioth/-/raw/twelve/android-12/vendor_boot.img
 versions:
 - twelve
 - twelve_plus


### PR DESCRIPTION
Starting with the August builds, the vendor_boot partition will need to be flashed on new installations.