### PR TITLE
wiki: Remove uses_custom_recovery for A/B devices and/or with AOSP rec available on the website

### DIFF
--- a/_data/devices/NB1.yml
+++ b/_data/devices/NB1.yml
@@ -64,7 +64,6 @@ screen:
   technology: IPS LCD
 soc: Qualcomm MSM8998 Snapdragon 835
 storage: 64/128 GB UFS 2.1 2-LANE
-uses_custom_recovery: true
 vendor: Nokia
 versions:
 - thirteen

--- a/_data/devices/begonia.yml
+++ b/_data/devices/begonia.yml
@@ -22,7 +22,6 @@ codename: begonia
 cpu: Helio G90T
 cpu_cores: '8'
 cpu_freq: 2 x 2.05 GHz & 6 x 2.0 GHz
-custom_recovery_link: https://sourceforge.net/projects/begonia-oss/files/TWRP-Dynamic/Dynamic-TWRP-Begonia-23-12-21.img/download
 deprecated: true
 deprecated_versions:
 - thirteen
@@ -73,7 +72,6 @@ sdcard:
   sizeMax: 512 GB
 soc: Mediatek Helio G90T
 storage: 64/128/256 GB
-uses_custom_recovery: true
 vendor: Xiaomi
 versions: []
 wifi: 802.11 a/b/g/n/ac, Dual-band, Wi-Fi Direct, Wi-Fi Display, Hotspot

--- a/_data/devices/merlinx.yml
+++ b/_data/devices/merlinx.yml
@@ -22,7 +22,6 @@ codename: merlinx
 cpu: Helio G85
 cpu_cores: '8'
 cpu_freq: 2 x 2.0 GHz & 6 x 1.8 GHz
-custom_recovery_link: https://sourceforge.net/projects/boxaltroms/files/recovery/Merlin_TWRP_3.5.2_%40surblazer.img/download
 deprecated: true
 deprecated_versions:
 - thirteen
@@ -73,7 +72,6 @@ sdcard:
   sizeMax: 512 GB
 soc: Mediatek Helio G85
 storage: 64/128 GB
-uses_custom_recovery: true
 vendor: Xiaomi
 versions: []
 wifi: 802.11 a/b/g/n/ac, Dual-band, Wi-Fi Direct, Wi-Fi Display, Hotspot

--- a/_data/devices/payton.yml
+++ b/_data/devices/payton.yml
@@ -67,7 +67,6 @@ sdcard:
   sizeMax: 256 GB
 soc: Qualcomm SDM630 Snapdragon 630
 storage: 32/64/128 GB
-uses_custom_recovery: true
 vendor: Motorola
 versions:
 - thirteen

--- a/_data/devices/sweet.yml
+++ b/_data/devices/sweet.yml
@@ -16,7 +16,6 @@ codename: sweet
 cpu: Kryo 470
 cpu_cores: '8'
 cpu_freq: 2 x 2.3 GHz + 6 x 1.8 GHz
-custom_recovery_link: https://sourceforge.net/projects/android-sweet/files/recovery/KewL_TWRP-3.6.2_12-sweet.img/download
 deprecated: false
 deprecated_versions:
 - twelve
@@ -66,7 +65,6 @@ sdcard:
   slot: dedicated
 soc: Qualcomm SM7150 Snapdragon 732
 storage: 64/128 GB
-uses_custom_recovery: true
 vendor: Xiaomi
 versions:
 - thirteen

--- a/_data/devices/tissot.yml
+++ b/_data/devices/tissot.yml
@@ -64,7 +64,6 @@ sdcard:
   sizeMax: 256 GB (hybrid SIM slot)
 soc: Qualcomm MSM8953 Snapdragon 625
 storage: 32/64 GB
-uses_custom_recovery: true
 vendor: Xiaomi
 versions:
 - thirteen


### PR DESCRIPTION
* Other non-deprecated devices soonTM

Signed-off-by: Henrique Pereira <hlcpereira@outlook.com.br>