### PR TITLE
Fixing fastboot command within install docs

### DIFF
--- a/_data/devices/vayu.yml
+++ b/_data/devices/vayu.yml
@@ -29,6 +29,7 @@ download_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>P
   release.
 gpu: Adreno 640
 install_method: fastboot_xiaomi_virtual_ab
+has_recovery_partition: true
 maintainers:
 - Alisson Grizotti
 name: POCO X3 Pro


### PR DESCRIPTION
Instead of saying `boot` this needed to say `recovery`:

![image](https://github.com/PixelExperience/wiki/assets/6559099/5572773e-f32d-43d0-beba-dbc312885338)
