### PR TITLE
wiki: dre: Flash vbmeta too

### DIFF
--- a/_data/devices/dre.yml
+++ b/_data/devices/dre.yml
@@ -7,7 +7,7 @@ before_install: needs_specific_android_fw
 before_install_args:
   version: 12
 before_install_custom: ab_copy_partitions
-before_recovery_install: dtbo_and_vendor_boot
+before_recovery_install: dre
 bluetooth:
   profiles:
   - A2DP + aptX HD
@@ -29,7 +29,6 @@ dimensions:
   width: 74.9 mm (2.95 in)
 download_boot: With the device powered off, hold <kbd>Volume Up</kbd> + <kbd>Volume
   Down</kbd> + <kbd>Power</kbd>.
-dtbo_download_link: https://gitlab.pixelexperience.org/android/vendor-blobs/wiki_blobs_dre/-/raw/thirteen/13/dtbo.img
 firmware_update: firmware_update_oneplus_sm4350
 gpu: Adreno 619
 image: dre.png
@@ -76,7 +75,6 @@ screen:
 soc: Qualcomm SM4350 Snapdragon 480
 storage: 64 GB UFS 2.1
 vendor: OnePlus
-vendor_boot_download_link: https://gitlab.pixelexperience.org/android/vendor-blobs/wiki_blobs_dre/-/raw/thirteen/13/vendor_boot.img
 versions:
 - thirteen
 - thirteen_plus

--- a/_includes/templates/device_specific/before_recovery_install_dre.md
+++ b/_includes/templates/device_specific/before_recovery_install_dre.md
@@ -1,0 +1,16 @@
+## Flashing compatible firmware
+
+{% include alerts/warning.html content="This device requires the vendor_boot, vbmeta, and dtbo images to be flashed prior to installing PixelExperience Recovery. The process to do so is described below." %}
+
+1. Download [this](https://gitlab.pixelexperience.org/android/vendor-blobs/wiki_blobs_dre/-/raw/thirteen/13/dtbo.img) `dtbo.img` file.
+2. Download [this](https://gitlab.pixelexperience.org/android/vendor-blobs/wiki_blobs_dre/-/raw/thirteen/13/vbmeta.img) `vbmeta.img` file.
+3. Download [this](https://gitlab.pixelexperience.org/android/vendor-blobs/wiki_blobs_dre/-/raw/thirteen/13/vendor_boot.img) `vendor_boot.img` file.
+4. Power off the device, and boot it into bootloader mode:
+   * {{ device.download_boot }}
+6. Flash a the downloaded images to your device by typing:
+
+```
+fastboot flash dtbo dtbo.img
+fastboot flash vbmeta vbmeta.img
+fastboot flash vendor_boot vendor_boot.img
+```


### PR DESCRIPTION
It looks like I have made a severe and continuous lapse in my judgement. Turns out that the vbmeta partition needs to be flashed before recovery, as reported by users and confirmed by https://github.com/LineageOS/lineage_wiki/commit/b806db4b91274fe46c125c368ce8a77c6013c029. I might as well bring back the device-specific before-recovery-install template to house this extra info, since we don't have a generic template for all three partitions.

This partially reverts commit d90a4cdec404fbaf41aae89a6125d04d60a0e032.