### PR TITLE
rosemary: Require MIUI 12.5.19.0.RKLINXM instead

### DIFF
--- a/_data/devices/rosemary.yml
+++ b/_data/devices/rosemary.yml
@@ -68,7 +68,7 @@ release:
 - 22087RA4DI: 2022-08-31
 - 2207117BPG: 2022-09-06
 required_bootloader:
-- 12.5.16.0.RKLMIXM
+- 12.5.19.0.RKLINXM
 screen:
   density: 428
   resolution: 1080x2340


### PR DESCRIPTION
* Flashing 12.5.19.0.RKLMIXM bricks `secret_r` (Redmi Note 11 SE). Besides, I've already switched rosemary-firmware to 12.5.19.0.RKLINXM.