### PR TITLE
Update recovery_install_odin.md

### DIFF
--- a/_includes/templates/recovery_install_odin.md
+++ b/_includes/templates/recovery_install_odin.md
@@ -56,8 +56,7 @@ The preferred method of installing a custom recovery is through Download Mode{% 
     {% include alerts/tip.html content="The filename may vary depending on your device, and the version of your custom recovery." %}
 11. Click "Start". A blue transfer bar will appear on the device showing the recovery image being flashed.
     {% include alerts/note.html content="The device will continue to display `Downloading... Do not turn off target!!` even after the process is complete. When the status message in the top left of the devices's display reports that the process is complete, you may proceed." %}
-12. Unplug the USB cable from your device.
-13. Manually reboot into recovery, this may require pulling the device's battery out and putting it back in, or if you have a non-removable battery, press the Volume Down + Power buttons for 8~10 seconds until the screen turns black & release the buttons *immediately* when it does, then boot to recovery:
+12. Manually reboot into recovery, press the Volume Down + Power buttons for 7~10 seconds (or unplugging the device, pulling device battery out and putting it back in, then replugging back the phone to a pc) until the screen turns black & release the buttons *immediately* when it does, then boot to recovery:
     * {{ device.recovery_boot }}
     {% include alerts/note.html content="Be sure to reboot into recovery immediately after installing the custom recovery. If you don't the custom recovery will be overwritten on boot." %}
 {%- include snippets/recovery_logo_note.md %}


### PR DESCRIPTION
12. is misleading, first you need to pull out the cable, then put it in, and the cable is required to enter the recovery.
a. the cable is not recommended to pull out by system
b. you need to have time to hold the necessary buttons as soon as the screen goes out, otherwise the phone will have to boot into the system and have to start the process again.

13. removed the option to remove the battery as it clutters the text and there is no firmware for Samsung smartphone with removable battery yet.